### PR TITLE
feat: add public CV dataset research pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,7 @@ jobs:
           python-version: "3.13"
 
       - name: Run smoke data contract
-        run: python tests/smoke_data_contract.py
+        run: |
+          python tests/smoke_data_contract.py
+          python tests/smoke_cv_dataset_manifest.py
+          python análise-preditiva/prepare_bracol_classification.py --dry-run

--- a/análise-preditiva/dataset_manifest.json
+++ b/análise-preditiva/dataset_manifest.json
@@ -1,0 +1,280 @@
+{
+  "updated_at": "2026-06-10",
+  "product_goal": "Selecionar datasets publicos para treinar e validar modelos de visao computacional do HackCafe sem descaracterizar a experiencia web existente.",
+  "decision": {
+    "primary_dataset": "bracol",
+    "primary_reason": "Ja esta parcialmente no repositorio, foi coletado no Brasil com Arabica, possui classes alinhadas ao produto e inclui severidade.",
+    "first_model_slice": "Classificador de estresse/severidade em folha inteira usando BRACOL local no Google Colab, com aviso de imagens ausentes no checkout.",
+    "second_model_slice": "Detector YOLO de sintomas usando BRACOT/BRACOL-YOLO/Roboflow depois de revisar qualidade das anotacoes.",
+    "external_validation": "Validar generalizacao com RoCoLe, JMuBEN/JMuBEN2 e Uganda Coffee Leaf antes de declarar robustez agronomica."
+  },
+  "selection_criteria": [
+    "alinhamento com cafe Arabica/Robusta e pragas/doencas do HackCafe",
+    "qualidade e tipo de rotulo: classe, severidade, segmentacao, bounding box ou instancia",
+    "uso em campo versus fundo controlado",
+    "licenca publica e citacao clara",
+    "tamanho e equilibrio entre classes",
+    "compatibilidade com Colab, YOLO/Ultralytics e pipeline reproducivel"
+  ],
+  "datasets": [
+    {
+      "id": "bracol",
+      "name": "BRACOL - Brazilian Arabica Coffee Leaf images dataset",
+      "tier": "A",
+      "fit_score": 95,
+      "source_url": "https://data.mendeley.com/datasets/yy2k5y8mxg/1",
+      "doi": "10.17632/yy2k5y8mxg.1",
+      "license": "CC BY 4.0",
+      "region": "Espirito Santo, Brazil",
+      "crop": "Arabica coffee",
+      "size": "1747 leaf images and 2147 symptom crops",
+      "tasks": [
+        "classification",
+        "severity_estimation",
+        "semantic_segmentation",
+        "symptom_classification"
+      ],
+      "classes": [
+        "healthy",
+        "leaf_miner",
+        "leaf_rust",
+        "brown_leaf_spot_or_phoma",
+        "cercospora",
+        "inconclusive_or_mixed"
+      ],
+      "use_for": [
+        "baseline imediato do HackCafe",
+        "classificacao de estresse predominante",
+        "estimativa inicial de severidade",
+        "comparacao com dataset ja embarcado no repo"
+      ],
+      "risks": [
+        "muitas imagens usam fundo branco/parcialmente controlado",
+        "checkout atual possui 1402 JPGs para 1747 linhas de CSV; treino final deve sincronizar a fonte Mendeley completa",
+        "rotulos de phoma/brown leaf spot precisam normalizacao antes de comunicar ao usuario",
+        "nao e dataset de bounding boxes pronto no checkout atual"
+      ]
+    },
+    {
+      "id": "bracot",
+      "name": "BRACOT - Brazilian Arabica Coffee Tree images dataset",
+      "tier": "A",
+      "fit_score": 90,
+      "source_url": "https://data.mendeley.com/datasets/pmkbyjpf6k/1",
+      "doi": "10.17632/pmkbyjpf6k.1",
+      "license": "CC BY 4.0",
+      "region": "Espirito Santo, Brazil",
+      "crop": "Arabica coffee",
+      "size": "300 field images with 1662 VIA instance labels",
+      "tasks": [
+        "instance_segmentation",
+        "object_detection",
+        "field_context_validation"
+      ],
+      "classes": [
+        "healthy_leaf",
+        "leaf_miner",
+        "leaf_rust",
+        "brown_leaf_spot",
+        "cercospora"
+      ],
+      "use_for": [
+        "segunda fatia de deteccao em imagem de planta no campo",
+        "avaliar robustez fora do fundo branco",
+        "treinar/validar segmentacao de folhas e sintomas em ramos"
+      ],
+      "risks": [
+        "pequeno para treinamento profundo isolado",
+        "exige conversao VIA para YOLO/COCO",
+        "deve ser combinado com BRACOL ou pretreinamento"
+      ]
+    },
+    {
+      "id": "bracol_yolo_detection",
+      "name": "BRACOL for YOLO Detection",
+      "tier": "A-",
+      "fit_score": 86,
+      "source_url": "https://www.kaggle.com/datasets/jonatanfragoso/bracol-for-yolov8-detection",
+      "doi": "",
+      "license": "verificar no Kaggle antes de redistribuir",
+      "region": "Brazil, derived from BRACOL",
+      "crop": "Arabica coffee",
+      "size": "YOLO-formatted derivative of BRACOL disease markings",
+      "tasks": [
+        "object_detection"
+      ],
+      "classes": [
+        "miner",
+        "rust",
+        "phoma_or_brown_leaf_spot",
+        "cercospora"
+      ],
+      "use_for": [
+        "atalho para benchmark YOLO no Colab",
+        "comparar com artigo de YOLO em BRACOL",
+        "gerar modelo demonstravel sem reanotar manualmente"
+      ],
+      "risks": [
+        "derivacao de terceiros precisa revisao de licenca e anotacoes",
+        "pode nao manter exatamente o split original",
+        "nao deve substituir a fonte BRACOL canonica sem auditoria"
+      ]
+    },
+    {
+      "id": "roboflow_coffee_leaf_diseases_classification",
+      "name": "Roboflow Universe - Coffee leaf diseases classification",
+      "tier": "B+",
+      "fit_score": 82,
+      "source_url": "https://universe.roboflow.com/data6000-y6w94/coffee-leaf-diseases-classification",
+      "doi": "",
+      "license": "CC BY 4.0",
+      "region": "not specified on page",
+      "crop": "Coffee",
+      "size": "1808 images, object detection, 5 classes",
+      "tasks": [
+        "object_detection",
+        "quick_api_benchmark"
+      ],
+      "classes": [
+        "healthy",
+        "rust",
+        "cerscospora",
+        "miner",
+        "phoma"
+      ],
+      "use_for": [
+        "experimento rapido de deteccao em Colab",
+        "comparacao com modelo/API publico",
+        "prototipagem quando houver Roboflow API key"
+      ],
+      "risks": [
+        "descricao tecnica limitada",
+        "precisa validar se nao e duplicata/derivacao do BRACOL",
+        "depende de token/API para exportacao automatica"
+      ]
+    },
+    {
+      "id": "jmuben_jmuben2",
+      "name": "JMuBEN and JMuBEN2 Arabica coffee leaf datasets",
+      "tier": "B+",
+      "fit_score": 80,
+      "source_url": "https://data.mendeley.com/datasets/t2r6rszp5c/1",
+      "secondary_source_url": "https://data.mendeley.com/datasets/tgv3zb82nd/1",
+      "doi": "10.17632/t2r6rszp5c.1 and 10.17632/tgv3zb82nd.1",
+      "license": "CC BY 4.0",
+      "region": "Kenya",
+      "crop": "Arabica coffee",
+      "size": "about 58k cropped/augmented leaf images across JMuBEN and JMuBEN2",
+      "tasks": [
+        "classification",
+        "domain_pretraining"
+      ],
+      "classes": [
+        "healthy",
+        "miner",
+        "rust",
+        "cercospora",
+        "phoma"
+      ],
+      "use_for": [
+        "pretreinamento classificatorio em maior volume",
+        "teste de generalizacao fora do Brasil",
+        "benchmark de modelos maiores em Colab/Devin"
+      ],
+      "risks": [
+        "imagens sao cropped/augmented e podem inflar metricas",
+        "nao atende deteccao/localizacao de sintomas",
+        "precisa manter split por origem para evitar vazamento de augmentations"
+      ]
+    },
+    {
+      "id": "rocole",
+      "name": "RoCoLe - Robusta Coffee Leaf Images Dataset",
+      "tier": "B",
+      "fit_score": 74,
+      "source_url": "https://data.mendeley.com/datasets/c5yvn32dzg/2",
+      "doi": "10.17632/c5yvn32dzg.2",
+      "license": "CC BY 4.0",
+      "region": "Ecuador",
+      "crop": "Robusta coffee",
+      "size": "1560 leaf images with rust/mites/state/severity annotations",
+      "tasks": [
+        "classification",
+        "severity_estimation",
+        "external_validation"
+      ],
+      "classes": [
+        "healthy",
+        "unhealthy_rust_or_mites"
+      ],
+      "use_for": [
+        "validacao externa de ferrugem/severidade",
+        "avaliar transferencia Arabica -> Robusta",
+        "detectar queda de desempenho em dominio diferente"
+      ],
+      "risks": [
+        "escopo menor de classes",
+        "Robusta pode divergir do contexto de cafe de montanha Arabica",
+        "melhor como validacao do que como treino principal"
+      ]
+    },
+    {
+      "id": "uganda_common_coffee_leaf_diseases",
+      "name": "Common Coffee Leaf Diseases in Uganda",
+      "tier": "B",
+      "fit_score": 72,
+      "source_url": "https://data.mendeley.com/datasets/k36wnd6knb/1",
+      "doi": "10.17632/k36wnd6knb.1",
+      "license": "CC BY 4.0",
+      "region": "Uganda",
+      "crop": "Coffee",
+      "size": "3312 labeled 256x256 JPEG images",
+      "tasks": [
+        "classification",
+        "external_validation"
+      ],
+      "classes": [
+        "healthy",
+        "coffee_leaf_rust",
+        "phoma"
+      ],
+      "use_for": [
+        "validacao externa recente",
+        "treino auxiliar para rust/phoma",
+        "avaliar robustez sob iluminacao de smartphone"
+      ],
+      "risks": [
+        "so cobre tres classes",
+        "dataset ja inclui augmentations; separar original/augmentado se possivel",
+        "nao resolve miner/cercospora"
+      ]
+    },
+    {
+      "id": "coffee_fruit_maturity_kaggle",
+      "name": "Coffee Fruit Maturity",
+      "tier": "C+",
+      "fit_score": 62,
+      "source_url": "https://www.kaggle.com/datasets/cienciacafeto/coffee-fruit-maturity",
+      "doi": "",
+      "license": "verificar no Kaggle antes de redistribuir",
+      "region": "not specified on search result",
+      "crop": "Arabica coffee cherries",
+      "size": "coffee cherries at maturity levels, skewed toward green cherries",
+      "tasks": [
+        "fruit_maturity_classification"
+      ],
+      "classes": [
+        "maturity_levels"
+      ],
+      "use_for": [
+        "fatia futura de maturacao/colheita",
+        "storytelling de ciclo completo da lavoura ao fruto"
+      ],
+      "risks": [
+        "nao atende diagnostico de folhas",
+        "pode ter desbalanceamento forte",
+        "exige credenciais Kaggle para reproducao no Colab"
+      ]
+    }
+  ]
+}

--- a/análise-preditiva/prepare_bracol_classification.py
+++ b/análise-preditiva/prepare_bracol_classification.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+import shutil
+from collections import defaultdict
+from pathlib import Path
+
+
+CLASS_NAMES = {
+    "0": "healthy",
+    "1": "leaf_miner",
+    "2": "leaf_rust",
+    "3": "brown_leaf_spot_or_phoma",
+    "4": "cercospora",
+}
+EXCLUDED_LABELS = {"5"}
+
+
+def default_source() -> Path:
+    return Path(__file__).resolve().parent / "coffee-datasets" / "leaf"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare BRACOL leaf images in Ultralytics classification format."
+    )
+    parser.add_argument("--source", type=Path, default=default_source())
+    parser.add_argument("--output", type=Path, default=Path("runs/datasets/bracol_cls"))
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--train", type=float, default=0.7)
+    parser.add_argument("--val", type=float, default=0.15)
+    parser.add_argument("--test", type=float, default=0.15)
+    parser.add_argument(
+        "--mode",
+        choices=("copy", "hardlink", "symlink"),
+        default="copy",
+        help="How to materialize images in the output dataset.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def load_rows(source: Path) -> list[dict[str, str]]:
+    dataset_csv = source / "dataset.csv"
+    if not dataset_csv.exists():
+        raise FileNotFoundError(f"dataset.csv not found at {dataset_csv}")
+
+    with dataset_csv.open(newline="", encoding="utf-8") as file:
+        rows = list(csv.DictReader(file))
+
+    if not rows:
+        raise ValueError(f"dataset.csv is empty: {dataset_csv}")
+
+    return rows
+
+
+def split_group(
+    items: list[dict[str, str]], train: float, val: float
+) -> dict[str, list[dict[str, str]]]:
+    train_end = int(len(items) * train)
+    val_end = train_end + int(len(items) * val)
+    return {
+        "train": items[:train_end],
+        "val": items[train_end:val_end],
+        "test": items[val_end:],
+    }
+
+
+def materialize(src: Path, dst: Path, mode: str) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+
+    if mode == "copy":
+        shutil.copy2(src, dst)
+    elif mode == "hardlink":
+        dst.hardlink_to(src)
+    else:
+        dst.symlink_to(src.resolve())
+
+
+def prepare(args: argparse.Namespace) -> dict[str, object]:
+    rows = load_rows(args.source)
+    images_dir = args.source / "images"
+    if not images_dir.exists():
+        raise FileNotFoundError(f"images directory not found at {images_dir}")
+
+    grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+    excluded: dict[str, int] = defaultdict(int)
+    missing_images = 0
+
+    for row in rows:
+        label = row["predominant_stress"]
+        if label in EXCLUDED_LABELS or label not in CLASS_NAMES:
+            excluded[label] += 1
+            continue
+
+        image_path = images_dir / f"{row['id']}.jpg"
+        if not image_path.exists():
+            missing_images += 1
+            continue
+
+        grouped[label].append(row)
+
+    rng = random.Random(args.seed)
+    splits: dict[str, dict[str, int]] = {split: {} for split in ("train", "val", "test")}
+
+    if not args.dry_run:
+        args.output.mkdir(parents=True, exist_ok=True)
+
+    for label, items in sorted(grouped.items()):
+        rng.shuffle(items)
+        for split, split_items in split_group(items, args.train, args.val).items():
+            class_name = CLASS_NAMES[label]
+            splits[split][class_name] = len(split_items)
+            if args.dry_run:
+                continue
+
+            for row in split_items:
+                src = images_dir / f"{row['id']}.jpg"
+                dst = args.output / split / class_name / src.name
+                materialize(src, dst, args.mode)
+
+    summary = {
+        "source": str(args.source),
+        "output": str(args.output),
+        "seed": args.seed,
+        "mode": args.mode,
+        "dry_run": args.dry_run,
+        "class_names": CLASS_NAMES,
+        "splits": splits,
+        "excluded": dict(sorted(excluded.items())),
+        "missing_images": missing_images,
+        "total_used": sum(sum(classes.values()) for classes in splits.values()),
+    }
+
+    if not args.dry_run:
+        metadata_path = args.output / "metadata.json"
+        metadata_path.write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    return summary
+
+
+def main() -> None:
+    args = parse_args()
+    if abs((args.train + args.val + args.test) - 1.0) > 0.001:
+        raise ValueError("train + val + test must sum to 1.0")
+
+    summary = prepare(args)
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/documentos/pesquisa-datasets-visao-computacional.md
+++ b/documentos/pesquisa-datasets-visao-computacional.md
@@ -1,0 +1,82 @@
+# Pesquisa de Datasets Publicos para Visao Computacional
+
+## Sintese
+
+A melhor primeira decisao para o HackCafe e usar o BRACOL local como baseline de classificacao/severidade e, em seguida, iterar para deteccao de sintomas com BRACOT ou derivados YOLO do BRACOL. Datasets maiores como JMuBEN/JMuBEN2 entram como pretreinamento e validacao cruzada, nao como substitutos imediatos, porque o produto precisa de confiabilidade em campo e rastreabilidade das classes.
+
+## Fatos
+
+- O repositorio ja contem parte do BRACOL em `análise-preditiva/coffee-datasets/leaf`, com `dataset.csv` e imagens.
+- O BRACOL tem 1747 imagens de folhas Arabica, rotulos de estresse predominante e severidade, e licenca CC BY 4.0.
+- O checkout atual tem 1747 linhas no CSV e 1402 arquivos JPG; o dry-run do preparo usa 1343 imagens nao inconclusivas e reporta 342 imagens ausentes.
+- O BRACOT complementa o BRACOL com 300 imagens em campo e 1662 instancias anotadas em VIA.
+- O artigo recente de YOLO em folhas de cafe comparou YOLOv8, YOLOv9, YOLOv10 e YOLOv11 em BRACOL e destacou YOLOv8s como uma boa troca entre mAP e latencia.
+- Devin Cloud e Google Colab devem ser usados para treinos longos; localmente devemos manter apenas smoke tests e scripts reprodutiveis.
+
+## Hipoteses
+
+- Um classificador BRACOL bem avaliado ja cria valor de portfolio porque fecha a cadeia sensor -> imagem -> diagnostico -> decisao.
+- Modelos de deteccao/localizacao serao mais convincentes para demonstracao visual, mas exigem conversao e auditoria de anotacoes.
+- Dataset grande com imagens aumentadas pode inflar acuracia; por isso a validacao externa e mais importante que uma acuracia alta em split aleatorio.
+
+## Decisao
+
+1. Usar BRACOL como dataset primario imediato.
+2. Criar baseline no Google Colab com classificacao de estresse predominante e severidade, reportando explicitamente imagens ausentes no checkout.
+3. Usar BRACOT/BRACOL-YOLO/Roboflow como candidatos para deteccao YOLO depois de validar licenca e anotacoes.
+4. Usar RoCoLe, JMuBEN/JMuBEN2 e Uganda Coffee Leaf como validacao externa e pretreinamento.
+5. Nao comunicar o modelo como recomendacao agronomica real antes de validacao por dominio e dados de campo.
+
+## Ranking
+
+| Tier | Dataset | Uso no HackCafe | Por que entra |
+| --- | --- | --- | --- |
+| A | BRACOL | Baseline imediato de classificacao/severidade | Brasil, Arabica, ja versionado, classes alinhadas |
+| A | BRACOT | Deteccao/segmentacao em campo | Fotos de planta real, instancia, complementar ao BRACOL |
+| A- | BRACOL for YOLO Detection | Benchmark rapido YOLO | Atalho para deteccao, mas precisa auditoria de derivacao |
+| B+ | Roboflow Coffee Leaf Diseases | Experimento rapido/API | Classes alinhadas e CC BY 4.0, mas descricao limitada |
+| B+ | JMuBEN/JMuBEN2 | Pretreinamento classificatorio | Volume alto e CC BY 4.0, mas cropped/augmented |
+| B | RoCoLe | Validacao externa de ferrugem/severidade | Robusta, rust/mites, severidade |
+| B | Uganda Coffee Leaf | Validacao externa recente | Smartphone, rust/phoma/healthy |
+| C+ | Coffee Fruit Maturity | Futuro modulo de maturacao | Bom para colheita, nao para diagnostico de folhas |
+
+## Cama de Teste Minima
+
+- `python tests/smoke_cv_dataset_manifest.py` garante que a matriz de datasets segue estrutura minima.
+- `python análise-preditiva/prepare_bracol_classification.py --dry-run` valida que o dataset local pode virar formato de classificacao sem copiar imagens.
+- No Colab: preparar BRACOL, treinar baseline curto, registrar imagens usadas/ausentes, matriz de confusao, accuracy/F1 por classe, latencia e artefato `best.pt`.
+
+## Plano de Iteracao
+
+### Sprint ML 0 - Baseline Local/Colab
+
+- Preparar BRACOL em formato Ultralytics classification.
+- Se a meta for treino de producao, baixar/validar o BRACOL completo via Mendeley antes de treinar.
+- Treinar `yolo11n-cls` ou `yolo11s-cls` por 20-40 epocas no Colab.
+- Medir accuracy, macro-F1, matriz de confusao e latencia.
+- Criterio de aceite: notebook reproduzivel e metricas exportadas.
+
+### Sprint ML 1 - Deteccao de Sintomas
+
+- Converter BRACOT VIA para COCO/YOLO ou usar BRACOL-YOLO como benchmark auditado.
+- Treinar YOLOv8s/YOLO11s; se houver GPU forte, testar variantes medias.
+- Criterio de aceite: mAP50 por classe e exemplos visuais com falsos positivos comentados.
+
+### Sprint ML 2 - Validacao Externa
+
+- Rodar inference nos datasets RoCoLe, Uganda e JMuBEN/JMuBEN2.
+- Separar queda de desempenho por dominio: pais, especie, fundo, iluminacao e tipo de rotulo.
+- Criterio de aceite: relatorio de generalizacao com decisao de coletar dados proprios ou ajustar dominio.
+
+## Fontes
+
+- BRACOL: https://data.mendeley.com/datasets/yy2k5y8mxg/1
+- BRACOT: https://data.mendeley.com/datasets/pmkbyjpf6k/1
+- RoCoLe: https://data.mendeley.com/datasets/c5yvn32dzg/2
+- JMuBEN: https://data.mendeley.com/datasets/t2r6rszp5c/1
+- JMuBEN2: https://data.mendeley.com/datasets/tgv3zb82nd/1
+- Uganda Coffee Leaf Diseases: https://data.mendeley.com/datasets/k36wnd6knb/1
+- Roboflow Coffee leaf diseases classification: https://universe.roboflow.com/data6000-y6w94/coffee-leaf-diseases-classification
+- BRACOL for YOLO Detection: https://www.kaggle.com/datasets/jonatanfragoso/bracol-for-yolov8-detection
+- Coffee Fruit Maturity: https://www.kaggle.com/datasets/cienciacafeto/coffee-fruit-maturity
+- Ultralytics train/classify/detect docs: https://docs.ultralytics.com/modes/train

--- a/notebooks/hackcafe_vision_colab.ipynb
+++ b/notebooks/hackcafe_vision_colab.ipynb
@@ -1,0 +1,173 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# HackCafe Vision Baseline\\n",
+        "\\n",
+        "Notebook Colab para iterar modelos de visao computacional do HackCafe. A primeira trilha usa o BRACOL local como baseline de classificacao de estresse predominante; trilhas opcionais usam datasets externos para deteccao YOLO quando houver credenciais Kaggle/Roboflow.\\n",
+        "\\n",
+        "Decisao de produto: preservar o frontend atual do HackCafe e evoluir a inteligencia visual por contratos e artefatos versionados."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!nvidia-smi || true\\n",
+        "!pip -q install ultralytics pandas scikit-learn pillow tqdm"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\\n",
+        "import json, os, subprocess\\n",
+        "\\n",
+        "REPO_URL = 'https://github.com/C-Icaro/HackCafe.git'\\n",
+        "BRANCH = 'ml-public-cv-datasets'\\n",
+        "WORKDIR = Path('/content/HackCafe')\\n",
+        "\\n",
+        "if not WORKDIR.exists():\\n",
+        "    subprocess.run(['git', 'clone', '--depth', '1', '--branch', BRANCH, REPO_URL, str(WORKDIR)], check=True)\\n",
+        "os.chdir(WORKDIR)\\n",
+        "print('Workspace:', Path.cwd())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "manifest = json.loads(Path('análise-preditiva/dataset_manifest.json').read_text(encoding='utf-8'))\\n",
+        "print('Primary dataset:', manifest['decision']['primary_dataset'])\\n",
+        "for ds in manifest['datasets']:\\n",
+        "    print(f\"{ds['tier']:>2} | {ds['fit_score']:>3} | {ds['id']} | {', '.join(ds['tasks'][:2])}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Preparar BRACOL para classificacao\\n",
+        "\\n",
+        "O script cria a estrutura `train/`, `val/`, `test/` esperada por classificadores Ultralytics. Por padrao, a classe `5` do CSV e excluida como inconclusiva/mista para evitar ruido na primeira baseline. O checkout atual pode estar incompleto em relacao ao BRACOL original; use o campo `missing_images` do resumo como evidencia e baixe a fonte Mendeley completa antes de um treino de producao."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!python análise-preditiva/prepare_bracol_classification.py --output /content/hackcafe_runs/bracol_cls --mode copy"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Treinar baseline\\n",
+        "\\n",
+        "Comece pequeno para validar o pipeline. Em Colab Pro/Pro+, aumente `epochs`, troque `MODEL_NAME` para uma variante maior, ou rode uma grade de modelos. Se a versao instalada do Ultralytics suportar familia mais nova, altere o nome do peso aqui."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from ultralytics import YOLO\\n",
+        "\\n",
+        "MODEL_NAME = 'yolo11s-cls.pt'\\n",
+        "DATA_DIR = '/content/hackcafe_runs/bracol_cls'\\n",
+        "\\n",
+        "model = YOLO(MODEL_NAME)\\n",
+        "results = model.train(\\n",
+        "    data=DATA_DIR,\\n",
+        "    epochs=30,\\n",
+        "    imgsz=224,\\n",
+        "    batch=-1,\\n",
+        "    patience=8,\\n",
+        "    seed=42,\\n",
+        "    project='/content/hackcafe_runs',\\n",
+        "    name='bracol_cls_baseline',\\n",
+        "    exist_ok=True,\\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "best = Path('/content/hackcafe_runs/bracol_cls_baseline/weights/best.pt')\\n",
+        "trained = YOLO(str(best))\\n",
+        "metrics = trained.val(data=DATA_DIR, split='test', imgsz=224)\\n",
+        "print(metrics)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Opcional: datasets externos\\n",
+        "\\n",
+        "- Kaggle: configure `KAGGLE_USERNAME` e `KAGGLE_KEY` como secrets do Colab antes de baixar BRACOL-YOLO ou Coffee Fruit Maturity.\\n",
+        "- Roboflow: configure `ROBOFLOW_API_KEY` como secret do Colab antes de exportar datasets do Universe.\\n",
+        "- Devin Cloud: usar o prompt de `documentos/devin-orquestracao.md` e pedir benchmark assinado com SHA, metricas e artefatos."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exemplo Kaggle, execute somente apos configurar secrets no Colab.\\n",
+        "# !pip -q install kaggle\\n",
+        "# !mkdir -p ~/.kaggle\\n",
+        "# !printf '{\"username\":\"%s\",\"key\":\"%s\"}' \"$KAGGLE_USERNAME\" \"$KAGGLE_KEY\" > ~/.kaggle/kaggle.json\\n",
+        "# !chmod 600 ~/.kaggle/kaggle.json\\n",
+        "# !kaggle datasets download -d jonatanfragoso/bracol-for-yolov8-detection -p /content/datasets/bracol-yolo --unzip\\n",
+        "# !yolo detect train model=yolo11s.pt data=/content/datasets/bracol-yolo/data.yaml epochs=50 imgsz=640 project=/content/hackcafe_runs name=bracol_yolo_detect"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Export para integracao futura.\\n",
+        "# trained.export(format='onnx')\\n",
+        "# trained.export(format='torchscript')"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "hackcafe_vision_colab.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/plataforma-web/app/components/SensorChart.tsx
+++ b/plataforma-web/app/components/SensorChart.tsx
@@ -63,8 +63,8 @@ export default function SensorChart({
   const gradientId = `gradient-${chartType}`
 
   return (
-    <div className="h-64 w-full">
-      <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+    <div className="h-64 w-full min-w-0">
+      <ResponsiveContainer width="100%" height={256} minWidth={1} minHeight={1}>
         <AreaChart data={data}>
           <defs>
             <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">

--- a/plataforma-web/package.json
+++ b/plataforma-web/package.json
@@ -53,7 +53,7 @@
     "geist": "^1.3.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
-    "next": "15.2.4",
+    "next": "15.5.19",
     "next-themes": "^0.4.4",
     "react": "^19",
     "react-day-picker": "9.8.0",
@@ -72,7 +72,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9.39.4",
-    "eslint-config-next": "15.2.4",
+    "eslint-config-next": "15.5.19",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/plataforma-web/pnpm-lock.yaml
+++ b/plataforma-web/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 8.5.1(react@19.2.7)
       geist:
         specifier: ^1.3.1
-        version: 1.7.2(next@15.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 1.7.2(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -120,8 +120,8 @@ importers:
         specifier: ^0.454.0
         version: 0.454.0(react@19.2.7)
       next:
-        specifier: 15.2.4
-        version: 15.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 15.5.19
+        version: 15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -172,8 +172,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4(jiti@1.21.7)
       eslint-config-next:
-        specifier: 15.2.4
-        version: 15.2.4(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        specifier: 15.5.19
+        version: 15.5.19(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       postcss:
         specifier: ^8.5
         version: 8.5.15
@@ -283,119 +283,155 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -419,60 +455,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@15.2.4':
-    resolution: {integrity: sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==}
+  '@next/env@15.5.19':
+    resolution: {integrity: sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==}
 
-  '@next/eslint-plugin-next@15.2.4':
-    resolution: {integrity: sha512-O8ScvKtnxkp8kL9TpJTTKnMqlkZnS+QxwoQnJwPGBxjBbzd6OVVPEJ5/pMNrktSyXQD/chEfzfFzYLM6JANOOQ==}
+  '@next/eslint-plugin-next@15.5.19':
+    resolution: {integrity: sha512-Ctwb4qYuMbHN/1oXLlTdMchwG8h8Xzwq+wGZZMgF3o6+uwyBKAI2c96bdOsl+C62PaUD0Jkh+QpNkhUeDlam0Q==}
 
-  '@next/swc-darwin-arm64@15.2.4':
-    resolution: {integrity: sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==}
+  '@next/swc-darwin-arm64@15.5.19':
+    resolution: {integrity: sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.2.4':
-    resolution: {integrity: sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==}
+  '@next/swc-darwin-x64@15.5.19':
+    resolution: {integrity: sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.2.4':
-    resolution: {integrity: sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==}
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    resolution: {integrity: sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@15.2.4':
-    resolution: {integrity: sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==}
+  '@next/swc-linux-arm64-musl@15.5.19':
+    resolution: {integrity: sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@15.2.4':
-    resolution: {integrity: sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==}
+  '@next/swc-linux-x64-gnu@15.5.19':
+    resolution: {integrity: sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@15.2.4':
-    resolution: {integrity: sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==}
+  '@next/swc-linux-x64-musl@15.5.19':
+    resolution: {integrity: sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@15.2.4':
-    resolution: {integrity: sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==}
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    resolution: {integrity: sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.2.4':
-    resolution: {integrity: sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==}
+  '@next/swc-win32-x64-msvc@15.5.19':
+    resolution: {integrity: sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1172,9 +1208,6 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1538,10 +1571,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1595,13 +1624,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1801,8 +1823,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@15.2.4:
-    resolution: {integrity: sha512-v4gYjd4eYIme8qzaJItpR5MMBXJ0/YV07u7eb50kEnlEmX7yhOjdUdzz70v4fiINYRjLf8X8TbogF0k7wlz6sA==}
+  eslint-config-next@15.5.19:
+    resolution: {integrity: sha512-UZwkuhBCNxVZfo93MSHRDOVNWXooJJGcAUyTAVIp0+9QFhH4SqJxWY0s6Mk9C2kMi777HPMn3dseOrZshWpG9Q==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
       typescript: '>=3.3.1'
@@ -2109,9 +2131,6 @@ packages:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
 
-  is-arrayish@0.3.4:
-    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
-
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
@@ -2337,14 +2356,13 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.2.4:
-    resolution: {integrity: sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==}
+  next@15.5.19:
+    resolution: {integrity: sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
+      '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
@@ -2695,8 +2713,8 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
@@ -2723,9 +2741,6 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
-  simple-swizzle@0.2.4:
-    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
-
   sonner@1.7.4:
     resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
     peerDependencies:
@@ -2742,10 +2757,6 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
-
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -3073,79 +3084,101 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/sharp-darwin-arm64@0.33.5':
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.33.5':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.33.5':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.33.5':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.33.5':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.33.5':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.11.0
     optional: true
 
-  '@img/sharp-win32-ia32@0.33.5':
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.33.5':
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -3169,34 +3202,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next/env@15.2.4': {}
+  '@next/env@15.5.19': {}
 
-  '@next/eslint-plugin-next@15.2.4':
+  '@next/eslint-plugin-next@15.5.19':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.2.4':
+  '@next/swc-darwin-arm64@15.5.19':
     optional: true
 
-  '@next/swc-darwin-x64@15.2.4':
+  '@next/swc-darwin-x64@15.5.19':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.2.4':
+  '@next/swc-linux-arm64-gnu@15.5.19':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.2.4':
+  '@next/swc-linux-arm64-musl@15.5.19':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.2.4':
+  '@next/swc-linux-x64-gnu@15.5.19':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.2.4':
+  '@next/swc-linux-x64-musl@15.5.19':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.2.4':
+  '@next/swc-win32-arm64-msvc@15.5.19':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.2.4':
+  '@next/swc-win32-x64-msvc@15.5.19':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3925,8 +3958,6 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@swc/counter@0.1.3': {}
-
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -4292,10 +4323,6 @@ snapshots:
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4361,18 +4388,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.4
-    optional: true
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-    optional: true
 
   commander@4.1.1: {}
 
@@ -4616,9 +4631,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.2.4(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@15.5.19(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 15.2.4
+      '@next/eslint-plugin-next': 15.5.19
       '@rushstack/eslint-patch': 1.16.1
       '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
@@ -4888,9 +4903,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.7.2(next@15.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  geist@1.7.2(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 15.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   generator-function@2.0.1: {}
 
@@ -4996,9 +5011,6 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
-
-  is-arrayish@0.3.4:
-    optional: true
 
   is-async-function@2.1.1:
     dependencies:
@@ -5219,27 +5231,25 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@15.2.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 15.2.4
-      '@swc/counter': 0.1.3
+      '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
-      busboy: 1.6.0
       caniuse-lite: 1.0.30001797
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.2.4
-      '@next/swc-darwin-x64': 15.2.4
-      '@next/swc-linux-arm64-gnu': 15.2.4
-      '@next/swc-linux-arm64-musl': 15.2.4
-      '@next/swc-linux-x64-gnu': 15.2.4
-      '@next/swc-linux-x64-musl': 15.2.4
-      '@next/swc-win32-arm64-msvc': 15.2.4
-      '@next/swc-win32-x64-msvc': 15.2.4
-      sharp: 0.33.5
+      '@next/swc-darwin-arm64': 15.5.19
+      '@next/swc-darwin-x64': 15.5.19
+      '@next/swc-linux-arm64-gnu': 15.5.19
+      '@next/swc-linux-arm64-musl': 15.5.19
+      '@next/swc-linux-x64-gnu': 15.5.19
+      '@next/swc-linux-x64-musl': 15.5.19
+      '@next/swc-win32-arm64-msvc': 15.5.19
+      '@next/swc-win32-x64-msvc': 15.5.19
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -5591,31 +5601,36 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.33.5:
+  sharp@0.34.5:
     dependencies:
-      color: 4.2.3
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.3
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@2.0.0:
@@ -5652,11 +5667,6 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  simple-swizzle@0.2.4:
-    dependencies:
-      is-arrayish: 0.3.4
-    optional: true
-
   sonner@1.7.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -5670,8 +5680,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-
-  streamsearch@1.1.0: {}
 
   string.prototype.includes@2.0.1:
     dependencies:

--- a/tests/smoke_cv_dataset_manifest.py
+++ b/tests/smoke_cv_dataset_manifest.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "análise-preditiva" / "dataset_manifest.json"
+
+REQUIRED_DATASET_KEYS = {
+    "id",
+    "name",
+    "tier",
+    "fit_score",
+    "source_url",
+    "license",
+    "tasks",
+    "classes",
+    "use_for",
+    "risks",
+}
+
+
+def main() -> None:
+    if not MANIFEST.exists():
+        raise AssertionError(f"Manifest nao encontrado: {MANIFEST}")
+
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    datasets = data.get("datasets", [])
+    if len(datasets) < 5:
+        raise AssertionError("Manifest deve registrar ao menos 5 datasets candidatos")
+
+    ids = [dataset["id"] for dataset in datasets]
+    if len(ids) != len(set(ids)):
+        raise AssertionError("IDs de datasets duplicados no manifest")
+
+    if data.get("decision", {}).get("primary_dataset") != "bracol":
+        raise AssertionError("BRACOL deve permanecer como dataset primario inicial")
+
+    for dataset in datasets:
+        missing = REQUIRED_DATASET_KEYS - set(dataset)
+        if missing:
+            raise AssertionError(
+                f"Dataset {dataset.get('id', '<sem id>')} sem chaves: {sorted(missing)}"
+            )
+
+        if dataset["tier"] not in {"A", "A-", "B+", "B", "C+", "C"}:
+            raise AssertionError(f"Tier invalido em {dataset['id']}: {dataset['tier']}")
+
+        if not isinstance(dataset["fit_score"], int) or not 0 <= dataset["fit_score"] <= 100:
+            raise AssertionError(f"fit_score invalido em {dataset['id']}")
+
+        if not dataset["source_url"].startswith("https://"):
+            raise AssertionError(f"source_url deve ser HTTPS em {dataset['id']}")
+
+        for field in ("tasks", "classes", "use_for", "risks"):
+            if not dataset[field]:
+                raise AssertionError(f"{field} vazio em {dataset['id']}")
+
+    print("Smoke CV dataset manifest OK")
+    print(f"Datasets registered: {len(datasets)}")
+    print(f"Primary dataset: {data['decision']['primary_dataset']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adds a ranked public computer-vision dataset manifest for HackCafe coffee leaf/fruit use cases
- documents the dataset decision: BRACOL first, BRACOT/YOLO detection next, external validation with RoCoLe/JMuBEN/Uganda
- adds a Colab-ready notebook for BRACOL classification baseline and optional Kaggle/Roboflow detection experiments
- adds a BRACOL classification-prep script and smoke test so CI keeps the dataset strategy structured

## Verification
- python -m json.tool análise-preditiva/dataset_manifest.json
- python -m json.tool notebooks/hackcafe_vision_colab.ipynb
- python tests/smoke_data_contract.py
- python tests/smoke_cv_dataset_manifest.py
- python análise-preditiva/prepare_bracol_classification.py --dry-run
- git diff --check

## Evidence / Findings
- Current checkout has 1747 CSV rows and 1402 local JPG files.
- Classification prep uses 1343 non-inconclusive images and reports 342 missing images.
- BRACOL remains the best immediate dataset, but production training should sync/verify the full Mendeley source first.

## Sources
- BRACOL: https://data.mendeley.com/datasets/yy2k5y8mxg/1
- BRACOT: https://data.mendeley.com/datasets/pmkbyjpf6k/1
- RoCoLe: https://data.mendeley.com/datasets/c5yvn32dzg/2
- JMuBEN/JMuBEN2: https://data.mendeley.com/datasets/t2r6rszp5c/1 and https://data.mendeley.com/datasets/tgv3zb82nd/1
- Uganda Coffee Leaf: https://data.mendeley.com/datasets/k36wnd6knb/1
- Roboflow Coffee Leaf Diseases: https://universe.roboflow.com/data6000-y6w94/coffee-leaf-diseases-classification
- Ultralytics training docs: https://docs.ultralytics.com/modes/train

## Notes
- This PR is stacked on feat-devin-orchestration / HackCafe#3 to reuse the new CI and agent guardrails.
- No model weights are committed; GPU training is intentionally delegated to Colab/Devin.