### PR TITLE
test: add cv model quality evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,23 @@ jobs:
           python tests/smoke_data_contract.py
           python tests/smoke_cv_dataset_manifest.py
           python análise-preditiva/prepare_bracol_classification.py --dry-run
+
+  cv-model-quality:
+    name: CV model quality smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: análise-preditiva/requirements.txt
+
+      - name: Install CV dependencies
+        run: python -m pip install -r análise-preditiva/requirements.txt
+
+      - name: Run CV model quality smoke
+        run: python tests/smoke_cv_model_quality.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+node_modules/
+.next/
+.docusaurus/
+build/
+dist/
+coverage/
+runs/
+
+.env
+.env.*
+!.env.example
+
+.vercel/
+*.log
+__pycache__/
+*.pyc

--- a/análise-preditiva/README.md
+++ b/análise-preditiva/README.md
@@ -113,6 +113,18 @@ detector = CoffeeDiseaseDetector(
 - Verifique se a imagem existe em `coffee-datasets/leaf/images/`
 - Use nomes exatos (ex: `1.jpg`, `100.jpg`)
 
+## Avaliacao de qualidade do modelo
+
+O peso versionado atualmente (`yolov8n.pt`) e um detector YOLO generico treinado em COCO, nao um modelo treinado nas classes BRACOL de cafe. Por isso, precisao, recall, F1 e matriz de confusao de doencas de cafe nao devem ser comunicados para esse peso.
+
+Use o avaliador abaixo para gerar uma evidencia reproduzivel:
+
+```bash
+python análise-preditiva/evaluate_cv_model_quality.py --sample-size 24 --output documentos/evidencias/avaliacao-modelo-visao-yolov8n.json
+```
+
+Quando houver um classificador treinado com classes compativeis com BRACOL (`healthy`, `leaf_miner`, `leaf_rust`, `brown_leaf_spot_or_phoma`, `cercospora`), o mesmo script calcula accuracy, precision, recall, F1 macro/ponderado, metricas por classe e matriz de confusao no split de teste.
+
 ## 🚀 Próximos Passos
 
 1. **Treinar modelo personalizado** para doenças específicas

--- a/análise-preditiva/evaluate_cv_model_quality.py
+++ b/análise-preditiva/evaluate_cv_model_quality.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from ultralytics import YOLO
+
+from prepare_bracol_classification import CLASS_NAMES, EXCLUDED_LABELS, default_source
+
+
+TARGET_CLASSES = list(CLASS_NAMES.values())
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate HackCafe computer vision model quality against BRACOL when compatible."
+    )
+    parser.add_argument("--model", type=Path, default=Path(__file__).resolve().parent / "yolov8n.pt")
+    parser.add_argument("--dataset", type=Path, default=default_source())
+    parser.add_argument("--output", type=Path, default=Path("runs/evaluation/cv_model_quality.json"))
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--sample-size", type=int, default=24)
+    parser.add_argument("--conf", type=float, default=0.25)
+    return parser.parse_args()
+
+
+def load_rows(dataset: Path) -> list[dict[str, str]]:
+    csv_path = dataset / "dataset.csv"
+    with csv_path.open(newline="", encoding="utf-8") as file:
+        return list(csv.DictReader(file))
+
+
+def split_group(items: list[dict[str, str]], train: float = 0.7, val: float = 0.15) -> dict[str, list[dict[str, str]]]:
+    train_end = int(len(items) * train)
+    val_end = train_end + int(len(items) * val)
+    return {
+        "train": items[:train_end],
+        "val": items[train_end:val_end],
+        "test": items[val_end:],
+    }
+
+
+def bracol_splits(dataset: Path, seed: int) -> tuple[dict[str, list[dict[str, str]]], dict[str, Any]]:
+    rows = load_rows(dataset)
+    images_dir = dataset / "images"
+    grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+    excluded = Counter()
+    missing_images = 0
+
+    for row in rows:
+        label = row["predominant_stress"]
+        if label in EXCLUDED_LABELS or label not in CLASS_NAMES:
+            excluded[label] += 1
+            continue
+
+        image_path = images_dir / f"{row['id']}.jpg"
+        if not image_path.exists():
+            missing_images += 1
+            continue
+
+        grouped[label].append(row)
+
+    rng = random.Random(seed)
+    splits: dict[str, list[dict[str, str]]] = {"train": [], "val": [], "test": []}
+    split_counts: dict[str, dict[str, int]] = {split: {} for split in splits}
+
+    for label, items in sorted(grouped.items()):
+        rng.shuffle(items)
+        class_name = CLASS_NAMES[label]
+        for split, split_items in split_group(items).items():
+            splits[split].extend(split_items)
+            split_counts[split][class_name] = len(split_items)
+
+    summary = {
+        "rows": len(rows),
+        "target_classes": TARGET_CLASSES,
+        "split_counts": split_counts,
+        "excluded": dict(sorted(excluded.items())),
+        "missing_images": missing_images,
+        "total_used": sum(len(items) for items in splits.values()),
+    }
+    return splits, summary
+
+
+def normalize_name(name: str) -> str:
+    return name.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def model_class_names(model: YOLO) -> list[str]:
+    names = getattr(model, "names", {})
+    if isinstance(names, dict):
+        return [str(names[key]) for key in sorted(names)]
+    if isinstance(names, list):
+        return [str(name) for name in names]
+    return []
+
+
+def class_overlap(model_names: list[str]) -> list[str]:
+    model_norm = {normalize_name(name) for name in model_names}
+    return [name for name in TARGET_CLASSES if normalize_name(name) in model_norm]
+
+
+def empty_metrics() -> dict[str, Any]:
+    return {
+        "accuracy": None,
+        "macro_precision": None,
+        "macro_recall": None,
+        "macro_f1": None,
+        "weighted_precision": None,
+        "weighted_recall": None,
+        "weighted_f1": None,
+        "per_class": {},
+        "confusion_matrix": None,
+    }
+
+
+def compute_metrics(y_true: list[str], y_pred: list[str], classes: list[str]) -> dict[str, Any]:
+    matrix = {actual: {predicted: 0 for predicted in classes} for actual in classes}
+    for actual, predicted in zip(y_true, y_pred):
+        matrix[actual][predicted] += 1
+
+    per_class = {}
+    total = len(y_true)
+    correct = sum(matrix[name][name] for name in classes)
+    weighted = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
+    macro = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
+
+    for name in classes:
+        tp = matrix[name][name]
+        fp = sum(matrix[actual][name] for actual in classes if actual != name)
+        fn = sum(matrix[name][predicted] for predicted in classes if predicted != name)
+        support = sum(matrix[name].values())
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+        per_class[name] = {
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "support": support,
+            "tp": tp,
+            "fp": fp,
+            "fn": fn,
+        }
+        macro["precision"] += precision
+        macro["recall"] += recall
+        macro["f1"] += f1
+        weighted["precision"] += precision * support
+        weighted["recall"] += recall * support
+        weighted["f1"] += f1 * support
+
+    class_count = len(classes)
+    return {
+        "accuracy": correct / total if total else 0.0,
+        "macro_precision": macro["precision"] / class_count if class_count else 0.0,
+        "macro_recall": macro["recall"] / class_count if class_count else 0.0,
+        "macro_f1": macro["f1"] / class_count if class_count else 0.0,
+        "weighted_precision": weighted["precision"] / total if total else 0.0,
+        "weighted_recall": weighted["recall"] / total if total else 0.0,
+        "weighted_f1": weighted["f1"] / total if total else 0.0,
+        "per_class": per_class,
+        "confusion_matrix": matrix,
+    }
+
+
+def evaluate_classifier(model: YOLO, rows: list[dict[str, str]], dataset: Path) -> dict[str, Any]:
+    y_true: list[str] = []
+    y_pred: list[str] = []
+    names = model_class_names(model)
+    normalized_to_target = {normalize_name(name): name for name in TARGET_CLASSES}
+
+    for row in rows:
+        image_path = dataset / "images" / f"{row['id']}.jpg"
+        result = model.predict(str(image_path), verbose=False)[0]
+        top1 = int(result.probs.top1)
+        predicted_name = names[top1]
+        normalized_pred = normalize_name(predicted_name)
+        if normalized_pred not in normalized_to_target:
+            raise ValueError(f"Classifier predicted class outside BRACOL target set: {predicted_name}")
+
+        y_true.append(CLASS_NAMES[row["predominant_stress"]])
+        y_pred.append(normalized_to_target[normalized_pred])
+
+    return compute_metrics(y_true, y_pred, TARGET_CLASSES)
+
+
+def detection_smoke(model: YOLO, rows: list[dict[str, str]], dataset: Path, sample_size: int, conf: float, seed: int) -> dict[str, Any]:
+    if sample_size <= 0:
+        return {"sample_size": 0, "detections": [], "class_counts": {}}
+
+    rng = random.Random(seed)
+    sample = rows[:]
+    rng.shuffle(sample)
+    sample = sample[: min(sample_size, len(sample))]
+
+    detections = []
+    class_counts = Counter()
+    started = time.perf_counter()
+
+    for row in sample:
+        image_path = dataset / "images" / f"{row['id']}.jpg"
+        result = model.predict(str(image_path), conf=conf, verbose=False)[0]
+        boxes = result.boxes
+        image_detections = []
+        if boxes is not None:
+            for box in boxes:
+                cls = int(box.cls[0].item())
+                name = model.names[cls]
+                score = float(box.conf[0].item())
+                image_detections.append({"class": name, "confidence": score})
+                class_counts[str(name)] += 1
+
+        detections.append(
+            {
+                "image_id": row["id"],
+                "ground_truth_class": CLASS_NAMES[row["predominant_stress"]],
+                "detections": image_detections,
+            }
+        )
+
+    elapsed = time.perf_counter() - started
+    return {
+        "sample_size": len(sample),
+        "confidence_threshold": conf,
+        "elapsed_seconds": elapsed,
+        "images_per_second": len(sample) / elapsed if elapsed else None,
+        "class_counts": dict(class_counts),
+        "detections": detections,
+    }
+
+
+def evaluate(args: argparse.Namespace) -> dict[str, Any]:
+    model = YOLO(str(args.model))
+    model_names = model_class_names(model)
+    splits, dataset_summary = bracol_splits(args.dataset, args.seed)
+    test_rows = splits["test"]
+    overlap = class_overlap(model_names)
+    task = str(getattr(model, "task", "unknown"))
+
+    report: dict[str, Any] = {
+        "model_path": str(args.model),
+        "model_task": task,
+        "model_class_count": len(model_names),
+        "model_classes_preview": model_names[:20],
+        "dataset": dataset_summary,
+        "evaluation_split": "test",
+        "evaluation_items": len(test_rows),
+        "target_class_overlap": overlap,
+        "metrics_available": False,
+        "quality_gate": "not_evaluable",
+        "reason": "",
+        "metrics": empty_metrics(),
+        "detection_smoke": None,
+    }
+
+    if task == "classify":
+        if len(overlap) != len(TARGET_CLASSES):
+            report["reason"] = "classification_model_class_space_does_not_match_bracol_targets"
+            return report
+
+        report["metrics"] = evaluate_classifier(model, test_rows, args.dataset)
+        report["metrics_available"] = True
+        report["quality_gate"] = "evaluated"
+        report["reason"] = "classification_model_matches_bracol_targets"
+        return report
+
+    if task == "detect":
+        report["reason"] = (
+            "model_is_coco_object_detector_but_bracol_local_ground_truth_is_image_level_classification; "
+            "precision_recall_map_for_coffee_disease_detection_requires task-specific classes and bounding-box labels"
+        )
+        report["detection_smoke"] = detection_smoke(
+            model=model,
+            rows=test_rows,
+            dataset=args.dataset,
+            sample_size=args.sample_size,
+            conf=args.conf,
+            seed=args.seed,
+        )
+        return report
+
+    report["reason"] = f"unsupported_model_task:{task}"
+    return report
+
+
+def main() -> None:
+    args = parse_args()
+    report = evaluate(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/documentos/avaliacao-qualidade-modelo-visao.md
+++ b/documentos/avaliacao-qualidade-modelo-visao.md
@@ -1,0 +1,109 @@
+# Avaliacao de Qualidade do Modelo de Visao Computacional
+
+Data da avaliacao: 10 de junho de 2026.
+
+## Resumo executivo
+
+O repositorio possui modelo `yolov8n.pt`, mas ele nao e um modelo treinado para doencas de cafe. Ele e um detector YOLO de objetos generico com 80 classes COCO, como `person`, `car`, `bird`, `kite` e `apple`.
+
+Conclusao: **nao ha precisao, recall, F1 ou mAP validos para doencas de cafe no modelo atual**. Comunicar esses numeros como qualidade agronomica seria incorreto.
+
+## Evidencia gerada
+
+Arquivo versionado:
+
+`documentos/evidencias/avaliacao-modelo-visao-yolov8n.json`
+
+Comando:
+
+```powershell
+python análise-preditiva\evaluate_cv_model_quality.py --sample-size 24 --output documentos\evidencias\avaliacao-modelo-visao-yolov8n.json
+```
+
+## Resultado
+
+| Item | Resultado |
+| --- | --- |
+| Modelo avaliado | `análise-preditiva/yolov8n.pt` |
+| Tipo do modelo | `detect` |
+| Classes do modelo | 80 classes COCO |
+| Classes alvo BRACOL | `healthy`, `leaf_miner`, `leaf_rust`, `brown_leaf_spot_or_phoma`, `cercospora` |
+| Sobreposicao entre classes | 0 |
+| Split avaliado | `test` |
+| Imagens no split de teste | 206 |
+| Gate de qualidade | `not_evaluable` |
+
+## Metricas de qualidade
+
+| Metrica | Valor | Interpretacao |
+| --- | --- | --- |
+| Accuracy | `null` | Nao calculavel para este modelo/dataset. |
+| Precision macro | `null` | Nao calculavel para este modelo/dataset. |
+| Recall macro | `null` | Nao calculavel para este modelo/dataset. |
+| F1 macro | `null` | Nao calculavel para este modelo/dataset. |
+| Precision ponderada | `null` | Nao calculavel para este modelo/dataset. |
+| Recall ponderado | `null` | Nao calculavel para este modelo/dataset. |
+| F1 ponderado | `null` | Nao calculavel para este modelo/dataset. |
+| Matriz de confusao | `null` | Exige classes de saida compativeis com BRACOL. |
+
+## Smoke de inferencia
+
+O avaliador rodou inferencia em 24 imagens do split de teste apenas para confirmar comportamento. Isso nao mede qualidade de doenca; mede compatibilidade pratica.
+
+| Classe COCO detectada | Quantidade |
+| --- | --- |
+| `kite` | 7 |
+| `bird` | 2 |
+| `apple` | 2 |
+
+Essa saida confirma que o peso atual esta operando no espaco semantico errado para o problema.
+
+## Dataset local usado como referencia
+
+| Item | Valor |
+| --- | --- |
+| Linhas no CSV BRACOL local | 1747 |
+| Imagens utilizaveis | 1343 |
+| Imagens ausentes no checkout | 342 |
+| Classe excluida como inconclusiva/mista | `5` com 62 linhas |
+| Treino | 938 imagens |
+| Validacao | 199 imagens |
+| Teste | 206 imagens |
+
+Distribuicao do teste:
+
+| Classe | Imagens |
+| --- | ---: |
+| `healthy` | 22 |
+| `leaf_miner` | 39 |
+| `leaf_rust` | 71 |
+| `brown_leaf_spot_or_phoma` | 53 |
+| `cercospora` | 21 |
+
+## Cadeia de decisao
+
+| Etapa | Registro |
+| --- | --- |
+| Hipotese | O peso atual poderia ter alguma utilidade mensuravel para triagem visual de cafe. |
+| Evidencia | O modelo e `detect`, tem 80 classes COCO e zero sobreposicao com as classes BRACOL. |
+| Decisao | Bloquear comunicacao de precision/recall/F1 de doencas para esse peso. |
+| Oportunidade | Treinar um classificador BRACOL ou detector com anotacoes BRACOT/BRACOL-YOLO. |
+| Story | Como maintainer, quero um avaliador que recuse metricas invalidas para nao inflar a demo. |
+| Criterio de aceite | Script gera JSON com `quality_gate=not_evaluable` para o modelo atual e calcula metricas quando houver classificador compativel. |
+| Metrica | Presenca de check `CV model quality smoke` no CI e evidencia JSON versionada. |
+
+## Proxima acao recomendada
+
+Treinar um baseline em Colab/Devin Cloud usando BRACOL em formato de classificacao:
+
+```powershell
+python análise-preditiva\prepare_bracol_classification.py --output runs\datasets\bracol_cls --mode copy
+```
+
+Depois treinar `yolo11n-cls` ou `yolo11s-cls` e reexecutar:
+
+```powershell
+python análise-preditiva\evaluate_cv_model_quality.py --model runs\train\bracol_cls\weights\best.pt
+```
+
+So apos esse passo sera correto reportar accuracy, precision, recall, F1 e matriz de confusao para doencas de cafe.

--- a/documentos/evidencias/avaliacao-modelo-visao-yolov8n.json
+++ b/documentos/evidencias/avaliacao-modelo-visao-yolov8n.json
@@ -1,0 +1,270 @@
+{
+  "model_path": "C:\\Users\\Usuario\\Documents\\Projetos para portifólio\\HackCafe\\análise-preditiva\\yolov8n.pt",
+  "model_task": "detect",
+  "model_class_count": 80,
+  "model_classes_preview": [
+    "person",
+    "bicycle",
+    "car",
+    "motorcycle",
+    "airplane",
+    "bus",
+    "train",
+    "truck",
+    "boat",
+    "traffic light",
+    "fire hydrant",
+    "stop sign",
+    "parking meter",
+    "bench",
+    "bird",
+    "cat",
+    "dog",
+    "horse",
+    "sheep",
+    "cow"
+  ],
+  "dataset": {
+    "rows": 1747,
+    "target_classes": [
+      "healthy",
+      "leaf_miner",
+      "leaf_rust",
+      "brown_leaf_spot_or_phoma",
+      "cercospora"
+    ],
+    "split_counts": {
+      "train": {
+        "healthy": 99,
+        "leaf_miner": 177,
+        "leaf_rust": 325,
+        "brown_leaf_spot_or_phoma": 242,
+        "cercospora": 95
+      },
+      "val": {
+        "healthy": 21,
+        "leaf_miner": 38,
+        "leaf_rust": 69,
+        "brown_leaf_spot_or_phoma": 51,
+        "cercospora": 20
+      },
+      "test": {
+        "healthy": 22,
+        "leaf_miner": 39,
+        "leaf_rust": 71,
+        "brown_leaf_spot_or_phoma": 53,
+        "cercospora": 21
+      }
+    },
+    "excluded": {
+      "5": 62
+    },
+    "missing_images": 342,
+    "total_used": 1343
+  },
+  "evaluation_split": "test",
+  "evaluation_items": 206,
+  "target_class_overlap": [],
+  "metrics_available": false,
+  "quality_gate": "not_evaluable",
+  "reason": "model_is_coco_object_detector_but_bracol_local_ground_truth_is_image_level_classification; precision_recall_map_for_coffee_disease_detection_requires task-specific classes and bounding-box labels",
+  "metrics": {
+    "accuracy": null,
+    "macro_precision": null,
+    "macro_recall": null,
+    "macro_f1": null,
+    "weighted_precision": null,
+    "weighted_recall": null,
+    "weighted_f1": null,
+    "per_class": {},
+    "confusion_matrix": null
+  },
+  "detection_smoke": {
+    "sample_size": 24,
+    "confidence_threshold": 0.25,
+    "elapsed_seconds": 2.260311099991668,
+    "images_per_second": 10.61800740618779,
+    "class_counts": {
+      "bird": 2,
+      "kite": 7,
+      "apple": 2
+    },
+    "detections": [
+      {
+        "image_id": "1068",
+        "ground_truth_class": "leaf_miner",
+        "detections": [
+          {
+            "class": "bird",
+            "confidence": 0.31734219193458557
+          }
+        ]
+      },
+      {
+        "image_id": "1093",
+        "ground_truth_class": "healthy",
+        "detections": []
+      },
+      {
+        "image_id": "1159",
+        "ground_truth_class": "cercospora",
+        "detections": []
+      },
+      {
+        "image_id": "1536",
+        "ground_truth_class": "leaf_rust",
+        "detections": []
+      },
+      {
+        "image_id": "596",
+        "ground_truth_class": "leaf_rust",
+        "detections": []
+      },
+      {
+        "image_id": "182",
+        "ground_truth_class": "healthy",
+        "detections": [
+          {
+            "class": "kite",
+            "confidence": 0.5111549496650696
+          }
+        ]
+      },
+      {
+        "image_id": "1594",
+        "ground_truth_class": "leaf_rust",
+        "detections": [
+          {
+            "class": "kite",
+            "confidence": 0.3833335340023041
+          }
+        ]
+      },
+      {
+        "image_id": "1131",
+        "ground_truth_class": "leaf_miner",
+        "detections": []
+      },
+      {
+        "image_id": "1188",
+        "ground_truth_class": "leaf_miner",
+        "detections": [
+          {
+            "class": "bird",
+            "confidence": 0.4008120000362396
+          }
+        ]
+      },
+      {
+        "image_id": "1245",
+        "ground_truth_class": "leaf_rust",
+        "detections": []
+      },
+      {
+        "image_id": "1144",
+        "ground_truth_class": "leaf_miner",
+        "detections": [
+          {
+            "class": "kite",
+            "confidence": 0.8668959736824036
+          }
+        ]
+      },
+      {
+        "image_id": "121",
+        "ground_truth_class": "leaf_rust",
+        "detections": [
+          {
+            "class": "kite",
+            "confidence": 0.8098117709159851
+          }
+        ]
+      },
+      {
+        "image_id": "561",
+        "ground_truth_class": "leaf_rust",
+        "detections": [
+          {
+            "class": "apple",
+            "confidence": 0.3091571033000946
+          }
+        ]
+      },
+      {
+        "image_id": "1579",
+        "ground_truth_class": "cercospora",
+        "detections": []
+      },
+      {
+        "image_id": "68",
+        "ground_truth_class": "leaf_miner",
+        "detections": []
+      },
+      {
+        "image_id": "683",
+        "ground_truth_class": "brown_leaf_spot_or_phoma",
+        "detections": [
+          {
+            "class": "apple",
+            "confidence": 0.3530702292919159
+          }
+        ]
+      },
+      {
+        "image_id": "1664",
+        "ground_truth_class": "leaf_rust",
+        "detections": [
+          {
+            "class": "kite",
+            "confidence": 0.6155700087547302
+          }
+        ]
+      },
+      {
+        "image_id": "21",
+        "ground_truth_class": "leaf_miner",
+        "detections": []
+      },
+      {
+        "image_id": "183",
+        "ground_truth_class": "healthy",
+        "detections": []
+      },
+      {
+        "image_id": "1410",
+        "ground_truth_class": "cercospora",
+        "detections": []
+      },
+      {
+        "image_id": "674",
+        "ground_truth_class": "healthy",
+        "detections": [
+          {
+            "class": "kite",
+            "confidence": 0.6434757113456726
+          }
+        ]
+      },
+      {
+        "image_id": "436",
+        "ground_truth_class": "brown_leaf_spot_or_phoma",
+        "detections": [
+          {
+            "class": "kite",
+            "confidence": 0.31469476222991943
+          }
+        ]
+      },
+      {
+        "image_id": "347",
+        "ground_truth_class": "brown_leaf_spot_or_phoma",
+        "detections": []
+      },
+      {
+        "image_id": "1311",
+        "ground_truth_class": "leaf_miner",
+        "detections": []
+      }
+    ]
+  }
+}

--- a/tests/smoke_cv_model_quality.py
+++ b/tests/smoke_cv_model_quality.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    output = Path(tempfile.gettempdir()) / "hackcafe_cv_model_quality_smoke.json"
+    if output.exists():
+        output.unlink()
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "análise-preditiva" / "evaluate_cv_model_quality.py"),
+            "--sample-size",
+            "0",
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        check=True,
+    )
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+
+    if report["model_task"] != "detect":
+        raise AssertionError(f"Expected default model to be detect, got {report['model_task']}")
+
+    if report["metrics_available"]:
+        raise AssertionError("Default YOLO COCO detector must not expose BRACOL disease metrics")
+
+    if report["quality_gate"] != "not_evaluable":
+        raise AssertionError(f"Expected not_evaluable gate, got {report['quality_gate']}")
+
+    if report["target_class_overlap"]:
+        raise AssertionError(f"Default model should not overlap BRACOL classes: {report['target_class_overlap']}")
+
+    print("Smoke CV model quality OK")
+    print(f"Model task: {report['model_task']}")
+    print(f"Reason: {report['reason']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumo

- adiciona avaliador reproduzivel para qualidade do modelo de visao computacional
- gera evidencia JSON para o `yolov8n.pt` atual
- documenta que o peso atual e YOLO COCO generico e nao tem precision/recall validos para doencas de cafe
- adiciona smoke test e job `CV model quality smoke` no GitHub Actions

## Resultado da avaliacao

- Modelo: `análise-preditiva/yolov8n.pt`
- Task: `detect`
- Classes: 80 classes COCO
- Sobreposicao com classes BRACOL: 0
- Split de teste BRACOL local: 206 imagens
- Gate: `not_evaluable`

As metricas `accuracy`, `precision`, `recall`, `F1` e matriz de confusao ficam `null` para este peso porque o modelo nao foi treinado nas classes alvo e o BRACOL local tem rotulos de classificacao por imagem, nao bounding boxes de deteccao.

## Validacao local

- `python tests/smoke_data_contract.py`
- `python tests/smoke_cv_dataset_manifest.py`
- `python análise-preditiva/prepare_bracol_classification.py --dry-run`
- `python tests/smoke_cv_model_quality.py`
- `python análise-preditiva/evaluate_cv_model_quality.py --sample-size 24 --output documentos/evidencias/avaliacao-modelo-visao-yolov8n.json`

## Proxima decisao

Treinar baseline `yolo11n-cls` ou `yolo11s-cls` no BRACOL completo via Colab/Devin Cloud; depois reexecutar o avaliador para obter precision/recall/F1 reais.